### PR TITLE
docs: update version references to v0.5.0

### DIFF
--- a/docs/FUTURE_ENHANCEMENTS.md
+++ b/docs/FUTURE_ENHANCEMENTS.md
@@ -367,5 +367,5 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for development guidelines.
 
 ---
 
-**Last Updated**: 2026-01-28  
+**Last Updated**: 2026-02-01  
 **Related**: [DIR-24 Implementation Plan](./DIR-24_RAG_IMPLEMENTATION_PLAN.md)

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -171,5 +171,5 @@ If you encounter issues not listed here:
 
 ---
 
-**Last Updated**: 2026-01-28  
-**Version**: 0.3.2
+**Last Updated**: 2026-02-01  
+**Version**: 0.5.0

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1039,7 +1039,7 @@ All objectives from the five iterations have been successfully completed:
   - Works with any `LLMClient` implementation (OpenAI, Anthropic, Ollama, LlamaCpp)
   - `ToolCallingConfig` for configuring max iterations, parallel execution, timeouts
   - New `generate_with_tools_and_history()` method added to `LLMClient` trait
-  - Deprecates `OllamaToolCoordinator` (still available for backward compatibility)
+  - **Breaking**: `OllamaToolCoordinator` removed - migrate to `ToolCoordinator`
 
 ### What's New in v0.4.0
 - **Anthropic Claude Provider**: Full support for Claude models via the Anthropic API
@@ -1079,7 +1079,7 @@ All objectives from the five iterations have been successfully completed:
 
 ### Next Immediate Actions
 1. Review and merge the implementation
-2. Create a release tag (v0.3.0)
+2. Create a release tag (v0.5.0)
 3. Consider publishing to crates.io
 
 ### For Questions or Issues

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ares-server = "0.2"
+//! ares-server = "0.5"
 //! ```
 //!
 //! ### Basic Example


### PR DESCRIPTION
## Summary

- Updates documentation to reflect v0.5.0 release

## Changes

- `src/lib.rs`: Update dependency example from `"0.2"` to `"0.5"`
- `docs/KNOWN_ISSUES.md`: Update version from 0.3.2 to 0.5.0
- `docs/PROJECT_STATUS.md`: Update release tag reference to v0.5.0, clarify OllamaToolCoordinator removal
- `docs/FUTURE_ENHANCEMENTS.md`: Update last updated date